### PR TITLE
Fixed typo in YAML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ development:
   password: secret
 production:
   <<: *defaults
-  password: <%= ENV[:secret] &>
+  password: <%= ENV[:secret] %>
 ```
 
 Configuration Retrieval


### PR DESCRIPTION
Hi,

I noticed a typo in your README: the closing of the expression was done with &> instead of %>.

Thanks for a great gem!

Cheers,

Benoit
